### PR TITLE
replace smoke with waffle

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "prepublishOnly": "yarn build && yarn tsc"
   },
   "devDependencies": {
-    "@defi-wonderland/smock": "^2.1.1",
     "@nomiclabs/hardhat-ethers": "^2.1.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/test/ExternalSCERC721Ledger.ts
+++ b/test/ExternalSCERC721Ledger.ts
@@ -51,7 +51,7 @@ describe('ExternalSCERC721Ledger contract tests', () => {
       this.fakeVerifierContract = await getFakeBalanceVerifier(this.owner)
       await this.fakeVerifierContract.mock.verifyProof.returns(true)
       // ERC721
-      this.fakeERC721 = await getFakeERC721()
+      this.fakeERC721 = await getFakeERC721(this.owner)
       // Ledger
       this.contract = await this.factory.deploy(
         this.fakeVerifierContract.address,

--- a/test/SCERC721Ledger.ts
+++ b/test/SCERC721Ledger.ts
@@ -67,7 +67,9 @@ describe('SCERC721Ledger and SCERC721Derivative contracts tests', () => {
       this.fakeVerifierContract = await getFakeBalanceVerifier(this.owner)
       await this.fakeVerifierContract.mock.verifyProof.returns(true)
       // ERC721
-      this.fakeERC721 = await getFakeERC721()
+      this.fakeERC721 = await getFakeERC721(this.owner)
+      await this.fakeERC721.mock.name.returns('Fake ERC721')
+      await this.fakeERC721.mock.symbol.returns('FAKE')
       // Ledger
       this.contract = await this.factory.deploy(
         this.fakeVerifierContract.address,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,5 @@
 import { BigNumber, Wallet, ethers } from 'ethers'
-import { smock } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { waffle } from 'hardhat'
 
 export const zeroAddress = '0x0000000000000000000000000000000000000000'
@@ -129,8 +129,35 @@ export function getFakeBalanceProof(
     input: getFakeBalanceVerifierInput(contract, network, nullifier, threshold),
   }
 }
-export function getFakeERC721() {
-  return smock.fake('ERC721')
+export async function getFakeERC721(signer: SignerWithAddress) {
+  return await waffle.deployMockContract(signer, [
+    {
+      inputs: [],
+      name: 'symbol',
+      outputs: [
+        {
+          internalType: 'string',
+          name: '',
+          type: 'string',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [],
+      name: 'name',
+      outputs: [
+        {
+          internalType: 'string',
+          name: '',
+          type: 'string',
+        },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ])
 }
 
 function getFakeBalanceVerifierInput(

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,7 +53,6 @@ __metadata:
   resolution: "@big-whale-labs/seal-cred-ledger-contract@workspace:."
   dependencies:
     "@big-whale-labs/constants": ^0.1.9
-    "@defi-wonderland/smock": ^2.1.1
     "@nomiclabs/hardhat-ethers": ^2.1.0
     "@nomiclabs/hardhat-etherscan": ^3.1.0
     "@nomiclabs/hardhat-waffle": ^2.0.3
@@ -109,27 +108,6 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": 0.3.9
   checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
-  languageName: node
-  linkType: hard
-
-"@defi-wonderland/smock@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@defi-wonderland/smock@npm:2.1.1"
-  dependencies:
-    "@nomiclabs/ethereumjs-vm": ^4.2.2
-    diff: ^5.0.0
-    lodash.isequal: ^4.5.0
-    lodash.isequalwith: ^4.4.0
-    rxjs: ^7.2.0
-    semver: ^7.3.5
-  peerDependencies:
-    "@ethersproject/abi": ^5
-    "@ethersproject/abstract-provider": ^5
-    "@ethersproject/abstract-signer": ^5
-    "@nomiclabs/hardhat-ethers": ^2
-    ethers: ^5
-    hardhat: ^2
-  checksum: 4e41f8f61f2155df1a09d715cb733fafdb7d4fe4f63c530921290a510859df70510026eae4c98f9de86ebe0fb203f62c2257a12d66e7637c654495cd97dd9ad7
   languageName: node
   linkType: hard
 
@@ -1250,29 +1228,6 @@ __metadata:
     "@nodelib/fs.scandir": 2.1.5
     fastq: ^1.6.0
   checksum: 190c643f156d8f8f277bf2a6078af1ffde1fd43f498f187c2db24d35b4b4b5785c02c7dc52e356497b9a1b65b13edc996de08de0b961c32844364da02986dc53
-  languageName: node
-  linkType: hard
-
-"@nomiclabs/ethereumjs-vm@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@nomiclabs/ethereumjs-vm@npm:4.2.2"
-  dependencies:
-    async: ^2.1.2
-    async-eventemitter: ^0.2.2
-    core-js-pure: ^3.0.1
-    ethereumjs-account: ^3.0.0
-    ethereumjs-block: ^2.2.2
-    ethereumjs-blockchain: ^4.0.3
-    ethereumjs-common: ^1.5.0
-    ethereumjs-tx: ^2.1.2
-    ethereumjs-util: ^6.2.0
-    fake-merkle-patricia-tree: ^1.0.1
-    functional-red-black-tree: ^1.0.1
-    merkle-patricia-tree: 3.0.0
-    rustbn.js: ~0.2.0
-    safe-buffer: ^5.1.1
-    util.promisify: ^1.0.0
-  checksum: 958e003813081947db14579af83f20139dc72c826fc128fade44cb87856eac32b9ff04be7ee20e708aa9ab8f2050df625d8edf298fbed5fbdbcc316c69ddd2fa
   languageName: node
   linkType: hard
 
@@ -5193,13 +5148,6 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
-  languageName: node
-  linkType: hard
-
-"diff@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "diff@npm:5.1.0"
-  checksum: c7bf0df7c9bfbe1cf8a678fd1b2137c4fb11be117a67bc18a0e03ae75105e8533dbfb1cda6b46beb3586ef5aed22143ef9d70713977d5fb1f9114e21455fba90
   languageName: node
   linkType: hard
 
@@ -10005,13 +9953,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.isequalwith@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.isequalwith@npm:4.4.0"
-  checksum: 428ba7a57c47ec05e2dd18c03a4b4c45dac524a46af7ce3f412594bfc7be6a5acaa51acf9ea113d0002598e9aafc6e19ee8d20bc28363145fcb4d21808c9039f
-  languageName: node
-  linkType: hard
-
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -13132,15 +13073,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.2.0":
-  version: 7.5.5
-  resolution: "rxjs@npm:7.5.5"
-  dependencies:
-    tslib: ^2.1.0
-  checksum: e034f60805210cce756dd2f49664a8108780b117cf5d0e2281506e9e6387f7b4f1532d974a8c8b09314fa7a16dd2f6cff3462072a5789672b5dcb45c4173f3c6
-  languageName: node
-  linkType: hard
-
 "safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -14698,13 +14630,6 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.1.0":
-  version: 2.4.0
-  resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Use waffle for mock contracts
- We still need the `smock` library to simulate a simple ERC721 contract. If we deploy an ERC721 mock, we will need to mock at least one of its methods, otherwise we get an error that none of the methods were mocked