### PR TITLE
for loops optimization

### DIFF
--- a/contracts/SCERC721Derivative.sol
+++ b/contracts/SCERC721Derivative.sol
@@ -125,11 +125,15 @@ contract SCERC721Derivative is Derivative {
     bytes memory tokenBytes = bytes(
       Strings.toHexString(uint256(uint160(originalContract)), 20)
     );
-    for (uint8 i = 0; i < 42; i++) {
+    for (uint8 i = 0; i < 42; ) {
       require(
         uint8(proof.input[i]) == uint8(tokenBytes[i]),
         "This ZK proof is not from the correct token contract"
       );
+
+      unchecked {
+        ++i;
+      }
     }
   }
 

--- a/contracts/SCERC721Ledger.sol
+++ b/contracts/SCERC721Ledger.sol
@@ -149,8 +149,13 @@ contract SCERC721Ledger is Ledger {
     returns (string memory, address)
   {
     bytes memory result = new bytes(addressLength);
-    for (uint256 i = startIndex; i < startIndex + addressLength; i++) {
+    uint256 length = startIndex + addressLength;
+    for (uint256 i = startIndex; i < length; ) {
       result[i] = bytes1(uint8(input[i]));
+
+      unchecked {
+        ++i;
+      }
     }
     string memory addressString = string(result);
     return (addressString, _toAddress(addressString));

--- a/contracts/SCEmailDerivative.sol
+++ b/contracts/SCEmailDerivative.sol
@@ -110,11 +110,17 @@ contract SCEmailDerivative is Derivative {
 
   function _checkEmail(EmailProof memory proof) internal view {
     bytes memory emailBytes = bytes(email);
-    for (uint8 i = 0; i < bytes(email).length; i++) {
+    uint256 length = bytes(email).length;
+
+    for (uint8 i = 0; i < length; ) {
       require(
         uint8(proof.input[i]) == uint8(emailBytes[i]),
         "This ZK proof is not from the correct email"
       );
+
+      unchecked {
+        ++i;
+      }
     }
   }
 

--- a/contracts/SCEmailLedger.sol
+++ b/contracts/SCEmailLedger.sol
@@ -126,15 +126,24 @@ contract SCEmailLedger is Ledger {
     uint256 length
   ) internal pure returns (string memory) {
     uint256 zeroIndex = 0;
-    for (uint256 i = startIndex; i < startIndex + length; i++) {
+    uint256 domainLength = startIndex + length;
+    for (uint256 i = startIndex; i < domainLength; ) {
       if (input[i] == 0) {
         zeroIndex = i;
         break;
       }
+
+      unchecked {
+        ++i;
+      }
     }
     bytes memory result = new bytes(zeroIndex);
-    for (uint256 i = startIndex; i < zeroIndex; i++) {
+    for (uint256 i = startIndex; i < zeroIndex; ) {
       result[i] = bytes1(uint8(input[i]));
+
+      unchecked {
+        ++i;
+      }
     }
     return string(result);
   }

--- a/contracts/SCExternalERC721Ledger.sol
+++ b/contracts/SCExternalERC721Ledger.sol
@@ -152,10 +152,15 @@ contract SCExternalERC721Ledger is SCERC721Ledger {
     );
     // Get the 0x0 index separating name from symbol
     uint256 zeroIndex;
-    for (uint256 i = contractLength; i < data.length; i++) {
+    uint256 length = data.length;
+    for (uint256 i = contractLength; i < length; ) {
       if (data[i] == 0) {
         zeroIndex = i;
         break;
+      }
+
+      unchecked {
+        ++i;
       }
     }
     // Get name string — between the end of contract at 42 and zero

--- a/contracts/SCFarcasterDerivative.sol
+++ b/contracts/SCFarcasterDerivative.sol
@@ -102,11 +102,15 @@ contract SCFarcasterDerivative is Derivative {
 
   function _checkFarcasterWord(FarcasterProof memory proof) internal pure {
     bytes memory farcasterBytes = bytes("farcaster");
-    for (uint8 i = 0; i < 9; i++) {
+    for (uint8 i = 0; i < 9; ) {
       require(
         uint8(proof.input[i]) == uint8(farcasterBytes[i]),
         "This ZK proof is not from the farcaster"
       );
+
+      unchecked {
+        ++i;
+      }
     }
   }
 


### PR DESCRIPTION
- Applied `for loop` optimization in all `mint` functions
- Cached length param and incrementing `i` in `unchecked` block

- SCEmailDerivative `169458` -> `166083`
- SCEmailLedger `2208640` -> `2195776`
- SCERC721Derivative `170648` -> `167204`
- SCERC721Ledger `2288215` -> `2270690`
- SCExternalERC721Ledger `2272432` -> `2254124`
- SCFarcasterDerivative `139462` -> `138724`
- SCFarcasterLedger `2101437` -> `2092485`
